### PR TITLE
forward attributes to wrapping div

### DIFF
--- a/addon/templates/components/animated-tools.hbs
+++ b/addon/templates/components/animated-tools.hbs
@@ -1,5 +1,5 @@
 {{#unless this.isHidden}}
-  <div class="animated-tools {{if this.isOpen "is-open"}}">
+  <div class="animated-tools {{if this.isOpen "is-open"}}" ...attributes>
     <div class="animated-tools-launcher" {{action "toggle"}}>
       {{motion-indicator}}
       ⏱{{! <--- there's an emoji here, in case your editor doesn't show it }}


### PR DESCRIPTION
This allows us to quickly add classes to the control.
In my case to raise the z-index using Tailwind, I tried to add `class="z-50"` and was surprised it didn't work.