### PR TITLE
Support ember-animated-docs

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,10 @@ module.exports = {
     if (this.project.pkg.name === 'ember-animated') {
       target = target.replace('ember-animated', '.');
     }
-    let file = resolve.sync(target, { basedir: this.project.root });
-    return file;
+    if (this.project.pkg.name === 'ember-animated-docs') {
+      target = target.replace('ember-animated', '..');
+    }
+    return resolve.sync(target, { basedir: this.project.root });
   },
 
   treeForAddon(tree) {


### PR DESCRIPTION
Latest `ember-animated-docs` docs app does not have `ember-animated`
in it's dependencies (linking done by `ember-cli-addon-docs`) hence resolution fails there.